### PR TITLE
fix: placeholder missing titles for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Create a report to help us improve
-title: ""
+title: "... is broken"
 labels: ["bug", "lifecycle/needs-triage"]
 projects: ["mauroalderete/20"]
 body:

--- a/.github/ISSUE_TEMPLATE/3-help-wanted.yml
+++ b/.github/ISSUE_TEMPLATE/3-help-wanted.yml
@@ -1,6 +1,6 @@
 name: Help Wanted
 description: Request help or suggest a topic to discuss
-title: ""
+title: "I need help with..."
 labels: ["help wanted", "lifecycle/needs-triage"]
 projects: ["mauroalderete/20"]
 body:


### PR DESCRIPTION
This pull request includes updates to the issue templates to provide default titles for new issues, making it easier for users to understand what information is needed.

Updates to issue templates:

* [`.github/ISSUE_TEMPLATE/1-bug-report.yml`](diffhunk://#diff-7ef8d00ae79e1c2ac42d02e7069549d69e2324e6cf37f8d4373428f360091babL3-R3): Changed the `title` field to provide a default value of "... is broken" to guide users in reporting bugs.
* [`.github/ISSUE_TEMPLATE/3-help-wanted.yml`](diffhunk://#diff-33f3235442ee70ee1a61b844b05b0ff7d5337e0adec66260d75c8d7a8169fc11L3-R3): Changed the `title` field to provide a default value of "I need help with..." to guide users in requesting help.