### PR TITLE
ci: set other token for trigger workflows before a release is created

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Create Release from PR
         id: create-release-from-pr
         if: github.event.head_commit.committer.username == 'web-flow'
+        env:
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Use this token if you don't want trigger other workflows before the release creation
+          GH_TOKEN: ${{ secrets.GH_PROJECT_AUTOMATION }} # Use this token if you want trigger other workflows before the release creation, for example, to create a package file
         run: |
           #!/bin/sh
 
@@ -78,6 +81,9 @@ jobs:
       - name: Create Release from Commits
         id: create-release-from-commits
         if: github.event.head_commit.committer.username != 'web-flow'
+        env:
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Use this token if you don't want trigger other workflows before the release creation
+          GH_TOKEN: ${{ secrets.GH_PROJECT_AUTOMATION }} # Use this token if you want trigger other workflows before the release creation, for example, to create a package file
         run: |
           #!/bin/sh
 


### PR DESCRIPTION
This pull request includes changes to the `versioning.yml` workflow file to enhance the release creation process by using a different GitHub token. This ensures that other workflows are triggered before the release creation, such as creating a package file.

Enhancements to release creation:

* [`.github/workflows/versioning.yml`](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68R67-R69): Added `GH_TOKEN` environment variable to the `Create Release from PR` job to trigger other workflows before the release creation.
* [`.github/workflows/versioning.yml`](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68R84-R86): Added `GH_TOKEN` environment variable to the `Create Release from Commits` job to trigger other workflows before the release creation.